### PR TITLE
Map primarycontent course module id through restore

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,19 @@
 
 All notable changes to the Simple course format plugin are documented in this file.
 
+## v0.7.2 (2026-07-29) - Beta
+
+### Added
+- Backup and restore plugin classes (`backup/moodle2/`) for the format.
+- PHPUnit tests covering backup and restore of the `primarycontent` section option.
+
+### Fixed
+- The `primarycontent` section option holds a course module id, which core restores verbatim.
+  It is now translated through the course_module mapping, so the teacher's chosen primary
+  activity survives a course restore, import or duplicate instead of being silently lost.
+  An unresolvable selection falls back to automatic rather than a stale id, and a merging
+  restore no longer risks disturbing a selection already made in the destination course.
+
 ## v0.7.1 (2026-03-20) - Beta
 
 ### Added

--- a/backup/moodle2/backup_format_simple_plugin.class.php
+++ b/backup/moodle2/backup_format_simple_plugin.class.php
@@ -1,0 +1,76 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Specialised backup for the Simple course format.
+ *
+ * @package   format_simple
+ * @category  backup
+ * @copyright 2026 South African Theological Seminary <ict@sats.ac.za>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+/**
+ * Specialised backup for the Simple course format.
+ *
+ * The 'primarycontent' section format option holds a course module id. Core backs section
+ * format options up verbatim, and restores them verbatim, so on restore the value would still
+ * point at the source course's module. We record the id separately here so that
+ * {@see restore_format_simple_plugin} can translate it through the course_module mapping.
+ *
+ * @package   format_simple
+ * @category  backup
+ * @copyright 2026 South African Theological Seminary <ict@sats.ac.za>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class backup_format_simple_plugin extends backup_format_plugin {
+    /**
+     * Adds the primary content course module id to the section backup structure.
+     *
+     * Nothing is added for courses using a different format, or for sections left on the
+     * default 'auto' setting, in which case there is no module id to translate.
+     *
+     * @return void
+     */
+    public function define_section_plugin_structure() {
+        global $DB;
+
+        // Every installed format plugin gets asked to contribute here, so only act on our own courses.
+        if ($DB->get_field('course', 'format', ['id' => $this->task->get_courseid()]) !== 'simple') {
+            return;
+        }
+
+        $plugin = $this->get_plugin_element();
+
+        $pluginwrapper = new backup_nested_element($this->get_recommended_name());
+        $plugin->add_child($pluginwrapper);
+
+        $primarycontent = new backup_nested_element('primarycontent', null, ['cmid']);
+        $pluginwrapper->add_child($primarycontent);
+
+        // Only sections with an explicit selection are worth recording; '0' means auto-select.
+        $primarycontent->set_source_sql(
+            "SELECT cfo.value AS cmid
+               FROM {course_format_options} cfo
+              WHERE cfo.courseid = ?
+                    AND cfo.sectionid = ?
+                    AND cfo.format = 'simple'
+                    AND cfo.name = 'primarycontent'
+                    AND cfo.value <> '0'",
+            [backup::VAR_COURSEID, backup::VAR_SECTIONID]
+        );
+    }
+}

--- a/backup/moodle2/restore_format_simple_plugin.class.php
+++ b/backup/moodle2/restore_format_simple_plugin.class.php
@@ -1,0 +1,105 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Specialised restore for the Simple course format.
+ *
+ * @package   format_simple
+ * @category  backup
+ * @copyright 2026 South African Theological Seminary <ict@sats.ac.za>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+/**
+ * Specialised restore for the Simple course format.
+ *
+ * Translates the course module id held in the 'primarycontent' section format option through
+ * the course_module mapping. Core restores format option values verbatim, so without this the
+ * option would still reference the source course's module and the teacher's choice of primary
+ * activity would be silently lost.
+ *
+ * @package   format_simple
+ * @category  backup
+ * @copyright 2026 South African Theological Seminary <ict@sats.ac.za>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class restore_format_simple_plugin extends restore_format_plugin {
+    /** @var int Course module id the source course had selected, 0 when none was recorded. */
+    protected $oldprimarycmid = 0;
+
+    /**
+     * Declares the section level data this plugin restores.
+     *
+     * @return restore_path_element[]
+     */
+    public function define_section_plugin_structure() {
+        return [
+            new restore_path_element('primarycontent', $this->get_pathfor('/primarycontent')),
+        ];
+    }
+
+    /**
+     * Remembers the source course module id for translation once modules have been restored.
+     *
+     * The mapping does not exist yet at this point: sections are restored before the activities
+     * they contain, so the actual work happens in {@see after_restore_section()}.
+     *
+     * @param array|stdClass $data The primarycontent element data.
+     * @return void
+     */
+    public function process_primarycontent($data) {
+        $data = (array) $data;
+        $this->oldprimarycmid = (int) ($data['cmid'] ?? 0);
+    }
+
+    /**
+     * Translates the stored course module id now that all activities have been restored.
+     *
+     * @return void
+     */
+    public function after_restore_section() {
+        global $DB;
+
+        if (empty($this->oldprimarycmid)) {
+            return;
+        }
+
+        $params = [
+            'courseid' => $this->task->get_courseid(),
+            'sectionid' => $this->task->get_sectionid(),
+            'format' => 'simple',
+            'name' => 'primarycontent',
+        ];
+        $record = $DB->get_record('course_format_options', $params, 'id, value');
+        if (!$record) {
+            // Restored into a course using a different format, so core skipped the option.
+            return;
+        }
+
+        // Core wrote the source value through untouched. If what is stored is anything else the
+        // section already carried its own selection, which a merging restore must not clobber.
+        if ((int) $record->value !== $this->oldprimarycmid) {
+            return;
+        }
+
+        // Fall back to 0 ('auto') when the selected activity was not part of this restore.
+        $newcmid = (int) $this->get_mappingid('course_module', $this->oldprimarycmid, 0);
+
+        if ($newcmid !== (int) $record->value) {
+            $DB->set_field('course_format_options', 'value', $newcmid, ['id' => $record->id]);
+        }
+    }
+}

--- a/tests/backup_restore_test.php
+++ b/tests/backup_restore_test.php
@@ -1,0 +1,323 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace format_simple;
+
+use backup;
+use backup_controller;
+use restore_controller;
+use restore_dbops;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once($CFG->dirroot . '/backup/util/includes/backup_includes.php');
+require_once($CFG->dirroot . '/backup/util/includes/restore_includes.php');
+require_once($CFG->dirroot . '/course/lib.php');
+
+/**
+ * Tests that the 'primarycontent' section format option survives backup and restore.
+ *
+ * Core copies section format option values verbatim, so the course module id this option holds
+ * has to be translated through the course_module mapping by the format's own restore plugin.
+ *
+ * @package    format_simple
+ * @copyright  2026 South African Theological Seminary <ict@sats.ac.za>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \restore_format_simple_plugin
+ * @covers     \backup_format_simple_plugin
+ */
+final class backup_restore_test extends \advanced_testcase {
+    /**
+     * Store a primarycontent selection for a section.
+     *
+     * Written straight to the table because validate_format_options() rebuilds the select's
+     * permitted values from section_format_options(true), whose choices come from request
+     * parameters that do not exist under CLI. The resulting row is identical to the one a
+     * successful save on /course/editsection.php produces.
+     *
+     * @param int $courseid The course the section belongs to.
+     * @param int $sectionid The course_sections id.
+     * @param int $cmid The course module id to select.
+     */
+    protected function set_primarycontent(int $courseid, int $sectionid, int $cmid): void {
+        global $DB;
+
+        $params = [
+            'courseid' => $courseid,
+            'format' => 'simple',
+            'sectionid' => $sectionid,
+            'name' => 'primarycontent',
+        ];
+        if ($existing = $DB->get_record('course_format_options', $params, 'id')) {
+            $DB->set_field('course_format_options', 'value', $cmid, ['id' => $existing->id]);
+        } else {
+            $DB->insert_record('course_format_options', (object) ($params + ['value' => $cmid]));
+        }
+    }
+
+    /**
+     * Read the primarycontent selection stored for a section number.
+     *
+     * @param int $courseid The course to look in.
+     * @param int $sectionnum The section number.
+     * @return int The selected course module id, 0 when unset.
+     */
+    protected function get_primarycontent(int $courseid, int $sectionnum): int {
+        global $DB;
+
+        $sectionid = $DB->get_field(
+            'course_sections',
+            'id',
+            ['course' => $courseid, 'section' => $sectionnum],
+            MUST_EXIST
+        );
+        return (int) $DB->get_field('course_format_options', 'value', [
+            'courseid' => $courseid,
+            'format' => 'simple',
+            'sectionid' => $sectionid,
+            'name' => 'primarycontent',
+        ]);
+    }
+
+    /**
+     * Back a course up and restore it, returning the destination course id.
+     *
+     * @param \stdClass $srccourse The course to back up.
+     * @param \stdClass|null $dstcourse Destination course, or null to create a new one.
+     * @param int $target One of the backup::TARGET_* constants.
+     * @return int The destination course id.
+     */
+    protected function backup_and_restore(
+        $srccourse,
+        $dstcourse = null,
+        $target = backup::TARGET_NEW_COURSE
+    ): int {
+        global $USER, $CFG;
+
+        // Turn off file logging, otherwise the file cannot be deleted on Windows.
+        $CFG->backup_file_logger_level = backup::LOG_NONE;
+
+        $bc = new backup_controller(
+            backup::TYPE_1COURSE,
+            $srccourse->id,
+            backup::FORMAT_MOODLE,
+            backup::INTERACTIVE_NO,
+            backup::MODE_IMPORT,
+            $USER->id
+        );
+        $backupid = $bc->get_backupid();
+        $bc->execute_plan();
+        $bc->destroy();
+
+        if ($dstcourse !== null) {
+            $newcourseid = $dstcourse->id;
+        } else {
+            $newcourseid = restore_dbops::create_new_course(
+                $srccourse->fullname,
+                $srccourse->shortname . '_2',
+                $srccourse->category
+            );
+        }
+
+        $rc = new restore_controller(
+            $backupid,
+            $newcourseid,
+            backup::INTERACTIVE_NO,
+            backup::MODE_GENERAL,
+            $USER->id,
+            $target
+        );
+        $this->assertTrue($rc->execute_precheck());
+        $rc->execute_plan();
+        $rc->destroy();
+
+        return $newcourseid;
+    }
+
+    /**
+     * The selected activity is still the selected activity after restore into a new course.
+     */
+    public function test_primarycontent_is_remapped_on_restore(): void {
+        global $DB;
+
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+
+        $generator = $this->getDataGenerator();
+        $course = $generator->create_course(
+            ['format' => 'simple', 'numsections' => 3],
+            ['createsections' => true]
+        );
+
+        $generator->create_module('page', ['course' => $course->id, 'section' => 1, 'name' => 'First page']);
+        $generator->create_module('page', ['course' => $course->id, 'section' => 1, 'name' => 'Second page']);
+        $third = $generator->create_module(
+            'page',
+            ['course' => $course->id, 'section' => 1, 'name' => 'Third page']
+        );
+
+        // Deliberately not the first activity, so falling back to the default would be visible.
+        $sectionid = $DB->get_field(
+            'course_sections',
+            'id',
+            ['course' => $course->id, 'section' => 1],
+            MUST_EXIST
+        );
+        $this->set_primarycontent($course->id, $sectionid, (int) $third->cmid);
+
+        $newcourseid = $this->backup_and_restore($course);
+
+        $restoredvalue = $this->get_primarycontent($newcourseid, 1);
+        $this->assertNotEquals(0, $restoredvalue, 'The selection was lost during restore.');
+        $this->assertNotEquals(
+            (int) $third->cmid,
+            $restoredvalue,
+            'The selection still points at the source course module.'
+        );
+
+        // It must resolve to a module in the new course, and be the same activity as before.
+        $modinfo = get_fast_modinfo($newcourseid);
+        $cm = $modinfo->get_cm($restoredvalue);
+        $this->assertEquals($newcourseid, $cm->course);
+        $this->assertEquals('Third page', $cm->name);
+    }
+
+    /**
+     * An existing selection in the destination course is not clobbered by a merging restore.
+     */
+    public function test_primarycontent_not_overwritten_when_merging(): void {
+        global $DB;
+
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+
+        $generator = $this->getDataGenerator();
+        $source = $generator->create_course(
+            ['format' => 'simple', 'numsections' => 3],
+            ['createsections' => true]
+        );
+        $sourcepage = $generator->create_module(
+            'page',
+            ['course' => $source->id, 'section' => 1, 'name' => 'Source page']
+        );
+        $sourcesectionid = $DB->get_field(
+            'course_sections',
+            'id',
+            ['course' => $source->id, 'section' => 1],
+            MUST_EXIST
+        );
+        $this->set_primarycontent($source->id, $sourcesectionid, (int) $sourcepage->cmid);
+
+        $target = $generator->create_course(
+            ['format' => 'simple', 'numsections' => 3],
+            ['createsections' => true]
+        );
+        $targetpage = $generator->create_module(
+            'page',
+            ['course' => $target->id, 'section' => 1, 'name' => 'Target page']
+        );
+        $targetsectionid = $DB->get_field(
+            'course_sections',
+            'id',
+            ['course' => $target->id, 'section' => 1],
+            MUST_EXIST
+        );
+        $this->set_primarycontent($target->id, $targetsectionid, (int) $targetpage->cmid);
+
+        $this->backup_and_restore($source, $target, backup::TARGET_EXISTING_ADDING);
+
+        $this->assertEquals(
+            (int) $targetpage->cmid,
+            $this->get_primarycontent($target->id, 1),
+            'A merging restore must leave the destination selection alone.'
+        );
+    }
+
+    /**
+     * Restoring into a course using a different format does not carry the option or error.
+     */
+    public function test_restore_into_other_format_is_harmless(): void {
+        global $DB;
+
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+
+        $generator = $this->getDataGenerator();
+        $source = $generator->create_course(
+            ['format' => 'simple', 'numsections' => 3],
+            ['createsections' => true]
+        );
+        $page = $generator->create_module(
+            'page',
+            ['course' => $source->id, 'section' => 1, 'name' => 'Source page']
+        );
+        $sourcesectionid = $DB->get_field(
+            'course_sections',
+            'id',
+            ['course' => $source->id, 'section' => 1],
+            MUST_EXIST
+        );
+        $this->set_primarycontent($source->id, $sourcesectionid, (int) $page->cmid);
+
+        $target = $generator->create_course(
+            ['format' => 'topics', 'numsections' => 3],
+            ['createsections' => true]
+        );
+
+        $this->backup_and_restore($source, $target, backup::TARGET_EXISTING_ADDING);
+
+        $this->assertEquals(0, $DB->count_records(
+            'course_format_options',
+            ['courseid' => $target->id, 'name' => 'primarycontent']
+        ));
+    }
+
+    /**
+     * A selection pointing at an activity excluded from the backup falls back to auto.
+     */
+    public function test_primarycontent_falls_back_when_module_missing(): void {
+        global $DB;
+
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+
+        $generator = $this->getDataGenerator();
+        $course = $generator->create_course(
+            ['format' => 'simple', 'numsections' => 3],
+            ['createsections' => true]
+        );
+        $generator->create_module('page', ['course' => $course->id, 'section' => 1, 'name' => 'Kept page']);
+
+        // Point the option at a course module id that is not part of this course at all.
+        $sectionid = $DB->get_field(
+            'course_sections',
+            'id',
+            ['course' => $course->id, 'section' => 1],
+            MUST_EXIST
+        );
+        $bogus = (int) $DB->get_field_sql('SELECT MAX(id) FROM {course_modules}') + 1000;
+        $this->set_primarycontent($course->id, $sectionid, $bogus);
+
+        $newcourseid = $this->backup_and_restore($course);
+
+        $this->assertEquals(
+            0,
+            $this->get_primarycontent($newcourseid, 1),
+            'An unresolvable selection must fall back to auto rather than a stale id.'
+        );
+    }
+}

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2026032000;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2026072900;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2025041400;        // Requires Moodle 5.0+.
 $plugin->component = 'format_simple';   // Full name of the plugin (used for diagnostics).
 $plugin->maturity  = MATURITY_BETA;
-$plugin->release   = '0.7.1';
+$plugin->release   = '0.7.2';


### PR DESCRIPTION
## Problem

The `primarycontent` section format option stores a **course module id**. Core's `restore_stepslib.php::process_course_format_options()` copies section format option values verbatim with no ID remapping, so after any restore, import or duplicate the option still pointed at the *source* course's cmid.

This failed silently — `classes/output/courseformat/content/section.php` finds no matching cmid and falls back to index 0, so the teacher's chosen primary activity was quietly replaced by the first learning-zone activity with no error anywhere.

## Fix

Adds the format's backup and restore plugin classes under `backup/moodle2/`:

- **backup** records the selected cmid into the section backup structure. Skips courses on other formats (every installed format plugin is asked to contribute) and sections left on `0` (auto).
- **restore** translates it via `get_mappingid('course_module', ...)`.

Two details worth noting for review:

- The remap runs in `after_restore_section()`, **not** `process_*`. Sections are restored before the activities they contain, so the `course_module` mapping does not exist yet at process time.
- It only overwrites when the stored value still equals the backed-up source cmid, so a merging restore does not clobber a selection the destination course already had.

An id that cannot be resolved (activity excluded from the backup) falls back to `0` = auto rather than leaving a stale pointer.

## Tests

`tests/backup_restore_test.php` adds 4 tests: remap into a new course, merge preserving an existing selection, restore into a `topics` course, and fallback for a missing module.

Verified locally against Moodle 5.0.7:

- Full plugin suite 40/40 passing (28 existing + 4 new + 8 external).
- Control run with the restore class removed fails 2 of the new tests, confirming they detect the bug rather than passing vacuously.
- `phpcs --standard=moodle` clean across the whole plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)