### PR TITLE
Validate primarycontent against the section, not the request

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,25 @@
 
 All notable changes to the Simple course format plugin are documented in this file.
 
+## v0.7.3 (2026-07-29) - Beta
+
+### Added
+- PHPUnit tests for the primary content option covering validation, form choices and section
+  duplication.
+
+### Fixed
+- The primary content selector no longer derives its permitted values from request parameters.
+  Saving a section through anything other than the section settings form silently discarded the
+  teacher's choice, because the choice list collapsed to "automatic" when the expected parameters
+  were absent. Validation now uses the section id the caller supplies, so every code path agrees.
+- Duplicating a section now points the copy at its own duplicated activity. Previously the copy
+  inherited the original section's course module id, which belongs to a different section, so the
+  duplicate silently fell back to featuring its first activity.
+
+### Changed
+- Section edit form choices are now supplied via `editsection_form()`, the documented extension
+  point for formats needing section context, rather than being inferred from the URL.
+
 ## v0.7.2 (2026-07-29) - Beta
 
 ### Added

--- a/lib.php
+++ b/lib.php
@@ -52,6 +52,13 @@ class format_simple extends core_courseformat\base {
     private const ZONE_HIDDEN = ['qbank'];
 
     /**
+     * Section currently being edited, so the primary content choices can be built for it.
+     *
+     * @var int|null Course_sections id, null when no section edit form is in play.
+     */
+    protected ?int $editingsectionid = null;
+
+    /**
      * Returns whether this course format uses sections.
      *
      * @return bool
@@ -324,7 +331,10 @@ class format_simple extends core_courseformat\base {
     /**
      * Definitions of the additional options that this course format uses for sections.
      *
-     * Provides a textarea for learning outcomes (one per line).
+     * Provides a textarea for learning outcomes (one per line) and a selector for the
+     * section's primary content. The selector's choices need to know which section is being
+     * edited, which the base API does not supply; {@see editsection_form()} records it, and
+     * {@see validate_format_options()} does the authoritative check when values are saved.
      *
      * @param bool $foreditform Whether the options are for the edit form.
      * @return array Array of options.
@@ -355,33 +365,6 @@ class format_simple extends core_courseformat\base {
                 ]
             );
 
-            // Build choices for the primary content selector.
-            $choices = [0 => get_string('primarycontent_auto', 'format_simple')];
-            $course = $this->get_course();
-            $modinfo = get_fast_modinfo($course);
-            // Determine which section is being edited from the form data.
-            $sectionnum = optional_param('sectionid', 0, PARAM_INT);
-            if ($sectionnum > 0) {
-                $sectioninfo = $modinfo->get_section_info_by_id($sectionnum);
-            } else {
-                $sectionnum = optional_param('id', 0, PARAM_INT);
-                $sectioninfo = $sectionnum > 0 ? $modinfo->get_section_info_by_id($sectionnum) : null;
-            }
-            if ($sectioninfo !== null) {
-                foreach ($modinfo->get_cms() as $cm) {
-                    if ($cm->section != $sectioninfo->id) {
-                        continue;
-                    }
-                    if (!$cm->is_visible_on_course_page()) {
-                        continue;
-                    }
-                    $zone = self::get_activity_zone($cm);
-                    if ($zone === 'learning') {
-                        $choices[$cm->id] = format_string($cm->name);
-                    }
-                }
-            }
-
             $options['primarycontent'] = array_merge(
                 $options['primarycontent'],
                 [
@@ -389,12 +372,159 @@ class format_simple extends core_courseformat\base {
                     'help' => 'primarycontent',
                     'help_component' => 'format_simple',
                     'element_type' => 'select',
-                    'element_attributes' => [$choices],
+                    'element_attributes' => [$this->get_primarycontent_choices($this->editingsectionid)],
                 ]
             );
         }
 
         return $options;
+    }
+
+    /**
+     * Course modules in a section that may serve as its primary content.
+     *
+     * @param int|null $sectionid The course_sections id, or null when no section is in context.
+     * @return \cm_info[] Candidate modules keyed by course module id, empty if there are none.
+     */
+    protected function get_primarycontent_candidates(?int $sectionid): array {
+        if (empty($sectionid)) {
+            return [];
+        }
+
+        $modinfo = get_fast_modinfo($this->get_course());
+        $sectioninfo = $modinfo->get_section_info_by_id($sectionid);
+        if ($sectioninfo === null) {
+            // The section belongs to a different course, or no longer exists.
+            return [];
+        }
+
+        $candidates = [];
+        foreach ($modinfo->get_cms() as $cm) {
+            if ($cm->section != $sectioninfo->id) {
+                continue;
+            }
+            if (!$cm->is_visible_on_course_page()) {
+                continue;
+            }
+            if (self::get_activity_zone($cm) !== 'learning') {
+                continue;
+            }
+            $candidates[$cm->id] = $cm;
+        }
+
+        return $candidates;
+    }
+
+    /**
+     * Select choices for the primary content option.
+     *
+     * @param int|null $sectionid The course_sections id, or null when no section is in context.
+     * @return array Course module id => activity name, always including 0 for automatic.
+     */
+    protected function get_primarycontent_choices(?int $sectionid): array {
+        $choices = [0 => get_string('primarycontent_auto', 'format_simple')];
+        foreach ($this->get_primarycontent_candidates($sectionid) as $cm) {
+            $choices[$cm->id] = format_string($cm->name);
+        }
+        return $choices;
+    }
+
+    /**
+     * Return an instance of moodleform to edit a specified section.
+     *
+     * The base API gives section_format_options() no way to know which section is being
+     * edited, so record it here. This is the documented extension point for formats that
+     * need section context while the edit form is built.
+     *
+     * @param mixed $action The action attribute for the form.
+     * @param array $customdata Custom data, with the section_info in the 'cs' field.
+     * @return \moodleform
+     */
+    public function editsection_form($action, $customdata = []): \moodleform {
+        if (!empty($customdata['cs']->id)) {
+            $this->editingsectionid = (int) $customdata['cs']->id;
+        }
+        return parent::editsection_form($action, $customdata);
+    }
+
+    /**
+     * Prepares values of course or section format options before storing them in DB.
+     *
+     * The parent checks 'primarycontent' against the select's choices, which
+     * section_format_options() can only build when a section happens to be in context. That
+     * makes the stored value depend on how the save was triggered. Validate it here instead,
+     * against the section id the caller actually supplied, so every code path agrees.
+     *
+     * @param array $rawdata Associative array of the proposed format options.
+     * @param int|null $sectionid Null for course format options.
+     * @return array Options that have valid values.
+     */
+    protected function validate_format_options(array $rawdata, ?int $sectionid = null): array {
+        $data = parent::validate_format_options($rawdata, $sectionid);
+
+        if ($sectionid !== null && array_key_exists('primarycontent', $rawdata)) {
+            $cmid = (int) $rawdata['primarycontent'];
+            $candidates = $this->get_primarycontent_candidates($sectionid);
+            // Anything that is not a current candidate falls back to automatic selection.
+            $data['primarycontent'] = array_key_exists($cmid, $candidates) ? $cmid : 0;
+        }
+
+        return $data;
+    }
+
+    /**
+     * Duplicate a section, carrying the primary content selection to the copied activity.
+     *
+     * The parent copies section format options before duplicating the modules, so at that
+     * point the new section is still empty and the selection cannot be resolved. Re-point it
+     * once the copies exist, matching each duplicate to its original by position.
+     *
+     * @param \section_info $originalsection The section to duplicate.
+     * @return \section_info The new section.
+     */
+    public function duplicate_section(\section_info $originalsection): \section_info {
+        $originalprimary = (int) ($this->get_format_options($originalsection)['primarycontent'] ?? 0);
+        $originalcmids = $originalprimary ? $this->get_duplicable_cmids($originalsection) : [];
+
+        $newsection = parent::duplicate_section($originalsection);
+
+        $position = $originalprimary ? array_search($originalprimary, $originalcmids, true) : false;
+        if ($position !== false) {
+            $newcmids = $this->get_duplicable_cmids($newsection);
+            // Only trust the pairing when the copy came out the same shape as the original.
+            if (count($newcmids) === count($originalcmids) && isset($newcmids[$position])) {
+                $this->update_section_format_options([
+                    'id' => $newsection->id,
+                    'primarycontent' => $newcmids[$position],
+                ]);
+            }
+        }
+
+        return get_fast_modinfo($this->get_course())->get_section_info_by_id($newsection->id);
+    }
+
+    /**
+     * Course module ids of a section, in the order the parent duplicates them.
+     *
+     * Mirrors the filtering in core_courseformat\base::duplicate_section() so that originals
+     * and copies line up index for index.
+     *
+     * @param \section_info $section The section to inspect.
+     * @return int[] Ordered course module ids.
+     */
+    protected function get_duplicable_cmids(\section_info $section): array {
+        $modinfo = get_fast_modinfo($this->get_course());
+        $cmids = [];
+
+        foreach ($modinfo->sections[$section->section] ?? [] as $cmid) {
+            $cm = $modinfo->cms[$cmid];
+            if (!$cm->is_of_type_that_can_display() || $cm->deletioninprogress) {
+                continue;
+            }
+            $cmids[] = (int) $cmid;
+        }
+
+        return $cmids;
     }
 
     /**

--- a/tests/primarycontent_test.php
+++ b/tests/primarycontent_test.php
@@ -1,0 +1,443 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace format_simple;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once($CFG->dirroot . '/course/lib.php');
+
+/**
+ * Tests for the primary content section option.
+ *
+ * The option stores a course module id. Its permitted values depend on which section is being
+ * edited, which the base format API does not pass to section_format_options(), so the format
+ * validates the value itself and keeps it correct when a section is duplicated.
+ *
+ * @package    format_simple
+ * @copyright  2026 South African Theological Seminary <ict@sats.ac.za>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \format_simple
+ */
+final class primarycontent_test extends \advanced_testcase {
+    /**
+     * Read the primarycontent value stored for a section.
+     *
+     * @param int $courseid The course to look in.
+     * @param int $sectionid The course_sections id.
+     * @return int The stored course module id, 0 when unset or absent.
+     */
+    protected function stored_value(int $courseid, int $sectionid): int {
+        global $DB;
+
+        return (int) $DB->get_field('course_format_options', 'value', [
+            'courseid' => $courseid,
+            'format' => 'simple',
+            'sectionid' => $sectionid,
+            'name' => 'primarycontent',
+        ]);
+    }
+
+    /**
+     * Build a course with a section 1 containing the requested page activities.
+     *
+     * @param string[] $pagenames Names of the pages to create in section 1.
+     * @return array{0: \stdClass, 1: \stdClass, 2: array<string, int>} Course, section, name => cmid.
+     */
+    protected function make_course(array $pagenames = ['First', 'Second', 'Third']): array {
+        global $DB;
+
+        $generator = $this->getDataGenerator();
+        $course = $generator->create_course(
+            ['format' => 'simple', 'numsections' => 3],
+            ['createsections' => true]
+        );
+
+        $cmids = [];
+        foreach ($pagenames as $name) {
+            $mod = $generator->create_module(
+                'page',
+                ['course' => $course->id, 'section' => 1, 'name' => $name]
+            );
+            $cmids[$name] = (int) $mod->cmid;
+        }
+
+        $section = $DB->get_record(
+            'course_sections',
+            ['course' => $course->id, 'section' => 1],
+            '*',
+            MUST_EXIST
+        );
+
+        return [$course, $section, $cmids];
+    }
+
+    // Group A: regression. Behaviour that must not change.
+
+    /**
+     * Course level options are still validated by the parent, untouched.
+     */
+    public function test_course_format_options_still_validated_by_parent(): void {
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+
+        [$course] = $this->make_course([]);
+        $format = course_get_format($course->id);
+
+        // A valid select value is accepted.
+        $format->update_course_format_options(['id' => $course->id, 'hiddensections' => 0]);
+        $this->assertEquals(0, $format->get_format_options()['hiddensections']);
+
+        // A value outside the select's choices is still rejected by the parent.
+        $format->update_course_format_options(['id' => $course->id, 'hiddensections' => 99]);
+        $this->assertEquals(
+            0,
+            $format->get_format_options()['hiddensections'],
+            'Parent validation of course level options must be left alone.'
+        );
+    }
+
+    /**
+     * The other section option is unaffected by the primarycontent handling.
+     */
+    public function test_learningoutcomes_option_unaffected(): void {
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+
+        [$course, $section] = $this->make_course();
+        $format = course_get_format($course->id);
+
+        $format->update_section_format_options([
+            'id' => $section->id,
+            'learningoutcomes' => "Outcome one\nOutcome two",
+        ]);
+
+        // Note that get_format_options() reads a bare int as a section number, not a section id.
+        $this->assertEquals(
+            "Outcome one\nOutcome two",
+            $format->get_format_options(1)['learningoutcomes']
+        );
+    }
+
+    /**
+     * Saving both section options together leaves each one correct.
+     */
+    public function test_both_section_options_save_together(): void {
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+
+        [$course, $section, $cmids] = $this->make_course();
+        $format = course_get_format($course->id);
+
+        $format->update_section_format_options([
+            'id' => $section->id,
+            'learningoutcomes' => 'An outcome',
+            'primarycontent' => $cmids['Third'],
+        ]);
+
+        $options = $format->get_format_options(1);
+        $this->assertEquals('An outcome', $options['learningoutcomes']);
+        $this->assertEquals($cmids['Third'], (int) $options['primarycontent']);
+    }
+
+    // Group B: validation correctness.
+
+    /**
+     * A valid selection is stored even with no request parameters present.
+     */
+    public function test_valid_selection_stored_without_request_params(): void {
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+
+        [$course, $section, $cmids] = $this->make_course();
+
+        course_get_format($course->id)->update_section_format_options([
+            'id' => $section->id,
+            'primarycontent' => $cmids['Third'],
+        ]);
+
+        $this->assertEquals($cmids['Third'], $this->stored_value($course->id, $section->id));
+    }
+
+    /**
+     * A module from another section of the same course is rejected.
+     */
+    public function test_cmid_from_another_section_rejected(): void {
+        global $DB;
+
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+
+        [$course, $section] = $this->make_course();
+        $other = $this->getDataGenerator()->create_module(
+            'page',
+            ['course' => $course->id, 'section' => 2, 'name' => 'Elsewhere']
+        );
+
+        course_get_format($course->id)->update_section_format_options([
+            'id' => $section->id,
+            'primarycontent' => (int) $other->cmid,
+        ]);
+
+        $this->assertEquals(
+            0,
+            $this->stored_value($course->id, $section->id),
+            'A module from a different section must not be accepted.'
+        );
+    }
+
+    /**
+     * A module from a different course is rejected.
+     */
+    public function test_cmid_from_another_course_rejected(): void {
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+
+        [$course, $section] = $this->make_course();
+        [, , $othercmids] = $this->make_course(['Foreign']);
+
+        course_get_format($course->id)->update_section_format_options([
+            'id' => $section->id,
+            'primarycontent' => $othercmids['Foreign'],
+        ]);
+
+        $this->assertEquals(
+            0,
+            $this->stored_value($course->id, $section->id),
+            'A module from another course must not be accepted.'
+        );
+    }
+
+    /**
+     * A module outside the learning zone cannot be the primary content.
+     */
+    public function test_non_learning_zone_module_rejected(): void {
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+
+        [$course, $section] = $this->make_course();
+        $forum = $this->getDataGenerator()->create_module(
+            'forum',
+            ['course' => $course->id, 'section' => 1, 'name' => 'Discussion']
+        );
+
+        // Confirm the premise: a forum is not learning zone content.
+        $cm = get_fast_modinfo($course->id)->get_cm((int) $forum->cmid);
+        $this->assertEquals('activities', \format_simple::get_activity_zone($cm));
+
+        course_get_format($course->id)->update_section_format_options([
+            'id' => $section->id,
+            'primarycontent' => (int) $forum->cmid,
+        ]);
+
+        $this->assertEquals(0, $this->stored_value($course->id, $section->id));
+    }
+
+    /**
+     * Zero means automatic and is always accepted.
+     */
+    public function test_zero_is_accepted_as_automatic(): void {
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+
+        [$course, $section, $cmids] = $this->make_course();
+        $format = course_get_format($course->id);
+
+        $format->update_section_format_options(['id' => $section->id, 'primarycontent' => $cmids['Third']]);
+        $this->assertEquals($cmids['Third'], $this->stored_value($course->id, $section->id));
+
+        $format->update_section_format_options(['id' => $section->id, 'primarycontent' => 0]);
+        $this->assertEquals(
+            0,
+            $this->stored_value($course->id, $section->id),
+            'Selecting automatic must clear the stored module id.'
+        );
+    }
+
+    /**
+     * A course module id that does not exist is rejected rather than throwing.
+     */
+    public function test_nonexistent_cmid_rejected(): void {
+        global $DB;
+
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+
+        [$course, $section] = $this->make_course();
+        $bogus = (int) $DB->get_field_sql('SELECT MAX(id) FROM {course_modules}') + 1000;
+
+        course_get_format($course->id)->update_section_format_options([
+            'id' => $section->id,
+            'primarycontent' => $bogus,
+        ]);
+
+        $this->assertEquals(0, $this->stored_value($course->id, $section->id));
+    }
+
+    // Group C: form choices.
+
+    /**
+     * The select offers the section's learning activities once the section is known.
+     */
+    public function test_form_choices_come_from_the_edited_section(): void {
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+
+        [$course, $section, $cmids] = $this->make_course();
+        $sectioninfo = get_fast_modinfo($course->id)->get_section_info_by_id($section->id);
+
+        $format = course_get_format($course->id);
+        $format->editsection_form(new \moodle_url('/course/editsection.php'), [
+            'cs' => $sectioninfo,
+            'editoroptions' => ['maxfiles' => 0],
+            'defaultsectionname' => 'Section 1',
+            'showonly' => '',
+        ]);
+
+        $choices = $format->section_format_options(true)['primarycontent']['element_attributes'][0];
+
+        $this->assertArrayHasKey(0, $choices, 'Automatic must always be offered.');
+        foreach (['First', 'Second', 'Third'] as $name) {
+            $this->assertArrayHasKey($cmids[$name], $choices);
+            $this->assertEquals($name, $choices[$cmids[$name]]);
+        }
+    }
+
+    /**
+     * With no section in context only the automatic choice is offered.
+     */
+    public function test_form_choices_without_section_context(): void {
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+
+        [$course] = $this->make_course();
+
+        $choices = course_get_format($course->id)
+            ->section_format_options(true)['primarycontent']['element_attributes'][0];
+
+        $this->assertEquals([0], array_keys($choices));
+    }
+
+    /**
+     * Request parameters no longer influence the choices offered.
+     */
+    public function test_form_choices_ignore_request_parameters(): void {
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+
+        [$course, $section, $cmids] = $this->make_course();
+
+        // Previously this shaped the choice list. It must now be irrelevant.
+        $_GET['sectionid'] = $section->id;
+        $_GET['id'] = $section->id;
+
+        try {
+            $choices = course_get_format($course->id)
+                ->section_format_options(true)['primarycontent']['element_attributes'][0];
+            $this->assertEquals(
+                [0],
+                array_keys($choices),
+                'Choices must come from the edited section, not the request.'
+            );
+
+            // And with the section supplied properly, the request params are still irrelevant.
+            $sectioninfo = get_fast_modinfo($course->id)->get_section_info_by_id($section->id);
+            $format = course_get_format($course->id);
+            $format->editsection_form(new \moodle_url('/course/editsection.php'), [
+                'cs' => $sectioninfo,
+                'editoroptions' => ['maxfiles' => 0],
+                'defaultsectionname' => 'Section 1',
+                'showonly' => '',
+            ]);
+            $choices = $format->section_format_options(true)['primarycontent']['element_attributes'][0];
+            $this->assertArrayHasKey($cmids['Third'], $choices);
+        } finally {
+            unset($_GET['sectionid'], $_GET['id']);
+        }
+    }
+
+    // Group D: section duplication.
+
+    /**
+     * Duplicating a section re-points the selection at the duplicated activity.
+     */
+    public function test_duplicate_section_remaps_primarycontent(): void {
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+
+        [$course, $section, $cmids] = $this->make_course();
+        $format = course_get_format($course->id);
+        $format->update_section_format_options([
+            'id' => $section->id,
+            'primarycontent' => $cmids['Third'],
+        ]);
+
+        $sectioninfo = get_fast_modinfo($course->id)->get_section_info_by_id($section->id);
+        $newsection = $format->duplicate_section($sectioninfo);
+
+        $newvalue = $this->stored_value($course->id, $newsection->id);
+        $this->assertNotEquals(0, $newvalue, 'The duplicated section lost its selection.');
+        $this->assertNotEquals(
+            $cmids['Third'],
+            $newvalue,
+            'The duplicate still points at the original section\'s activity.'
+        );
+
+        // It must be an activity inside the duplicated section, and the same one by name.
+        $cm = get_fast_modinfo($course->id)->get_cm($newvalue);
+        $this->assertEquals($newsection->id, $cm->section);
+        $this->assertEquals('Third', $cm->name);
+    }
+
+    /**
+     * A section set to automatic duplicates as automatic.
+     */
+    public function test_duplicate_section_keeps_automatic(): void {
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+
+        [$course, $section] = $this->make_course();
+
+        $sectioninfo = get_fast_modinfo($course->id)->get_section_info_by_id($section->id);
+        $newsection = course_get_format($course->id)->duplicate_section($sectioninfo);
+
+        $this->assertEquals(0, $this->stored_value($course->id, $newsection->id));
+    }
+
+    /**
+     * Duplicating an empty section does not error.
+     */
+    public function test_duplicate_empty_section(): void {
+        global $DB;
+
+        $this->resetAfterTest(true);
+        $this->setAdminUser();
+
+        [$course] = $this->make_course();
+        $empty = $DB->get_record(
+            'course_sections',
+            ['course' => $course->id, 'section' => 2],
+            '*',
+            MUST_EXIST
+        );
+
+        $sectioninfo = get_fast_modinfo($course->id)->get_section_info_by_id($empty->id);
+        $newsection = course_get_format($course->id)->duplicate_section($sectioninfo);
+
+        $this->assertEquals(0, $this->stored_value($course->id, $newsection->id));
+    }
+}

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2026072900;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2026072901;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2025041400;        // Requires Moodle 5.0+.
 $plugin->component = 'format_simple';   // Full name of the plugin (used for diagnostics).
 $plugin->maturity  = MATURITY_BETA;
-$plugin->release   = '0.7.2';
+$plugin->release   = '0.7.3';


### PR DESCRIPTION
Follow-up to #6. Same option, different failure.

## Problem

`section_format_options(true)` built the primary content select's permitted values from `optional_param('sectionid')` / `optional_param('id')`. Core's `validate_format_options()` then silently unsets any value outside that list — so what got stored depended on which URL triggered the save.

Measured on a real course (course A, section 343, target cmid 709):

| Request params | Choices built | Result |
|---|---|---|
| none (CLI / programmatic) | `[0]` | dropped |
| `id` = 343 (correct section) | `[0,708,709]` | stored |
| `sectionid` = 343 | `[0,708,709]` | stored |
| `id` = 120 (course id) | `[0]` | dropped |
| foreign section id | `[0]` | dropped |

**Section duplication was affected in a worse way.** The Duplicate control menu item builds its URL with `sectionid` = the *original* section's id, so the original selection passed validation and was written to the copy while still pointing at a module in the source section:

```
original section 351: 711=First, 712=Second, 713=Third, primarycontent=713
duplicated section 353: 714=First, 715=Second, 716=Third
  primarycontent stored = 713  <- lives in section 351, not 353
```

The copy then quietly featured its first activity. `duplicate_section()` copies format options *before* duplicating the modules, so core cannot map this itself.

## Approach

No core format defines a section option holding an ID, so there is no pattern to copy. The nearest precedent, `format_singleactivity::activitytype`, derives its choices from the format object's own state (`$this->courseid`) and never from the request — that principle is what this follows.

Two seams, both intended for this:

- `editsection_form()` — documented extension point (*"Format plugins may extend editsection_form if they want to have custom edit section form"*), and `editsection.php` passes `'cs' => $sectioninfo`. Records the section being edited so the choices can be built for it.
- `validate_format_options()` — already receives the authoritative `$sectionid` that `section_format_options()` is never given. Validates the submitted cmid against that section directly.
- `duplicate_section()` — re-points the selection after the modules are copied, pairing each duplicate to its original by position, falling back to automatic if the copy is not the same shape.

## Tests

`tests/primarycontent_test.php`, 15 cases in four groups: regression (course options and `learningoutcomes` untouched), validation (valid selection with no request params; rejects other-section, other-course, non-learning-zone and nonexistent cmids; accepts 0), form choices (from `cs`, ignores request params, auto-only with no section), duplication (remaps, keeps automatic, empty section).

Verified locally on Moodle 5.0.7:

- Full plugin suite **55/55** (40 existing + 15 new); `phpcs --standard=moodle` clean.
- **Control run:** reverting `lib.php` fails 6 of the 15 — exactly the behaviour-change cases; the 9 regression/guard cases still pass, as they should.
- **Isolated control:** with validation fixed but `duplicate_section()` disabled, the duplication test fails on its own, so that override is independently proven necessary.
- Real-world probe of the exact broken scenario now stores the duplicated activity rather than the cross-section pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)